### PR TITLE
[30% Review] Tabulating volume data and calculating their totals

### DIFF
--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -37,8 +37,41 @@ class HouseKeeper {
     this.monitor = monitor;
     this.tagger = tagger;
   }
+  
+  _calculateTotals(volumesByType) {
+    let totalVolumes = new Object();
+    
+    volumesByType.forEach(function(volume) {
+      if (typeof volume != 'undefined') {
+        let totalDataPerType;
+        
+        if (volume.VolumeType in totalVolumes) {
+          totalDataPerType = new Object();
+          totalDataPerType['count'] = 1;
+          totalDataPerType['gb'] = volume.Size;
+        }
+        else {
+          totalDataPerType = totalVolumes[volume.VolumeType];
+          totalDataPerType['count']++;
+          totalDataPerType['gb'] += volume.Size;
+        }
+        totalVolumes[volume.VolumeType] = totalDataPerType;
+      }
+    });
+    
+    return totalVolumes;
+  }
 
-  async _handleVolumeData(volume) {}
+  // Tabulate the required data
+  async _handleVolumeData(volume) {
+    return new Promise((resolve, reject) => {
+      let volumeData = {};
+      volumeData['type'] = volume.VolumeType;
+      volumeData['size'] = volume.Size;
+      volumeData['status'] = volume.State;
+      resolve(volumeData);
+    });
+  }
 
   async _sweepVolumes(region) {
     let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
@@ -48,7 +81,8 @@ class HouseKeeper {
       }],
     });
 
-    await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    let volumesByType = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    return this._calculateTotals(volumesByType);
   }
 
   async sweep() {
@@ -80,7 +114,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      await this._sweepVolumes(region);
+      let totalVolumes = await this._sweepVolumes(region);
 
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -296,7 +296,6 @@ class HouseKeeper {
 
 
       outcomeInfo[region] = {
-        volumes: totalVolumes,
         state: {
           missingRequests,
           missingInstances,

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -55,7 +55,6 @@ class HouseKeeper {
             gb: volume.size,
           };
         }
-
       }
     });
     
@@ -64,10 +63,11 @@ class HouseKeeper {
 
   // Tabulate the required data
   async _handleVolumeData(volume) {
-    let volumeData = {};
-    volumeData['type'] = volume.VolumeType;
-    volumeData['size'] = volume.Size;
-    volumeData['status'] = volume.State;
+    let volumeData = {
+      type: volume.VolumeType,
+      size: volume.Size,
+      status: volume.State,
+    };
 
     return new Promise((resolve, reject) => {
       resolve(volumeData);
@@ -116,7 +116,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      let totalVolumes = await this._sweepVolumes(region)    
+      let totalVolumes = await this._sweepVolumes(region);
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{
           Name: 'key-name',

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -64,11 +64,12 @@ class HouseKeeper {
 
   // Tabulate the required data
   async _handleVolumeData(volume) {
+    let volumeData = {};
+    volumeData['type'] = volume.VolumeType;
+    volumeData['size'] = volume.Size;
+    volumeData['status'] = volume.State;
+
     return new Promise((resolve, reject) => {
-      let volumeData = {};
-      volumeData['type'] = volume.VolumeType;
-      volumeData['size'] = volume.Size;
-      volumeData['status'] = volume.State;
       resolve(volumeData);
     });
   }
@@ -81,7 +82,7 @@ class HouseKeeper {
       }],
     });
 
-    let volumesByType = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    let volumesByType = await Promise.all(volumes.Volumes.map(volume => this._handleVolumeData(volume)));
     return this._calculateTotals(volumesByType);
   }
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -38,24 +38,24 @@ class HouseKeeper {
     this.tagger = tagger;
   }
   
-  _calculateTotals(volumesByType) {
-    let totalVolumes = new Object();
+  _calculateTotals(tabulatedVolumes) {
+    let totalVolumes = {};
     
-    volumesByType.forEach(function(volume) {
+    tabulatedVolumes.forEach(function(volume) {
       if (typeof volume != 'undefined') {
-        let totalDataPerType;
-        
-        if (volume.VolumeType in totalVolumes) {
-          totalDataPerType = new Object();
-          totalDataPerType['count'] = 1;
-          totalDataPerType['gb'] = volume.Size;
+        if (volume.type in totalVolumes) {
+          totalVolumes[volume.type] = {
+            count: totalVolumes[volume.type]['count'] + 1,
+            gb: totalVolumes[volume.type]['gb'] += volume.size,
+          };
         }
         else {
-          totalDataPerType = totalVolumes[volume.VolumeType];
-          totalDataPerType['count']++;
-          totalDataPerType['gb'] += volume.Size;
+          totalVolumes[volume.type] = {
+            count: 1,
+            gb: volume.size,
+          };
         }
-        totalVolumes[volume.VolumeType] = totalDataPerType;
+
       }
     });
     
@@ -81,9 +81,10 @@ class HouseKeeper {
         Values: ['available', 'in-use'],
       }],
     });
-
-    let volumesByType = await Promise.all(volumes.Volumes.map(volume => this._handleVolumeData(volume)));
-    return this._calculateTotals(volumesByType);
+    
+    let tabulatedVolumes = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    let totalVolumes = this._calculateTotals(tabulatedVolumes);
+    return totalVolumes;
   }
 
   async sweep() {
@@ -115,8 +116,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      let totalVolumes = await this._sweepVolumes(region);
-
+      let totalVolumes = await this._sweepVolumes(region)    
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{
           Name: 'key-name',
@@ -297,6 +297,7 @@ class HouseKeeper {
 
 
       outcomeInfo[region] = {
+        volumes: totalVolumes,
         state: {
           missingRequests,
           missingInstances,

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -83,8 +83,7 @@ class HouseKeeper {
     });
     
     let tabulatedVolumes = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
-    let totalVolumes = this._calculateTotals(tabulatedVolumes);
-    return totalVolumes;
+    return this._calculateTotals(tabulatedVolumes);
   }
 
   async sweep() {

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -137,7 +137,6 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
-      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,
@@ -196,7 +195,6 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(regions.length);
     assume(await state.listSpotRequests()).has.lengthOf(regions.length);
     assume(outcome[region]).deeply.equals({
-      volumes: {},
       state: {
         missingRequests: 1,
         missingInstances: 1,
@@ -317,7 +315,6 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
-      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -137,6 +137,7 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
+      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,
@@ -195,6 +196,7 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(regions.length);
     assume(await state.listSpotRequests()).has.lengthOf(regions.length);
     assume(outcome[region]).deeply.equals({
+      volumes: {},
       state: {
         missingRequests: 1,
         missingInstances: 1,
@@ -315,6 +317,7 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
+      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,
@@ -333,7 +336,7 @@ describe('House Keeper', () => {
     }
   });
 
-  it('should call sweepVolumes exactly once', async() => {
+  it('should call sweepVolumes exactly once per region', async() => {
     houseKeeperMock.expects("_sweepVolumes").exactly(regions.length);
     
     await houseKeeper.sweep();
@@ -342,14 +345,14 @@ describe('House Keeper', () => {
 
   it('should not fail if no volume data is returned', async() => {
     houseKeeperMock.expects("_handleVolumeData").never();
-
+    
     await houseKeeper.sweep();
     houseKeeperMock.verify();
   });
   
   it('should call handleVolumeData exactly once per volume', async() => {
     houseKeeperMock.expects("_handleVolumeData").twice();
-      
+    
     describeVolumesStub.withArgs(sinon.match(function(value) {
       return value === ec2['us-west-2'] 
     })).returns({
@@ -379,8 +382,7 @@ describe('House Keeper', () => {
         VolumeType: "standard",
       }]
     });
-
-     
+    
     await houseKeeper.sweep();
     houseKeeperMock.verify();
    });


### PR DESCRIPTION
## Overview
`_sweepVolumes(region)` now returns the total number of volumes and the total size of the volumes per region and per type in the shape: { $type: { count: INT, gb: INT}}. `_handleVolumeData()` tabulates the required data and `_calculateTotals()` converts that tabulated data into getting the totals.

`houseKeeper.sweep()` returns these totals as part of the object `outcomeInfo`. However, this implementation doesn't follow the requested shape of { $region: { $vol_type: { count: INT, gb: INT}}} because `outcomeInfo` is now of the shape: { $region: { **volumes:** { $vol_type: { count: INT, gb: INT}}}}. `outcomeInfo` contains other info besides the total volume data so I wasn't sure how to insert it into `outcomeInfo` without specifying the key 'volumes'.

Perhaps, we don't even want to place it into `outcomeInfo`. We could probably take out the call to `_sweepVolumes()` from inside `await Promise.all(this.regions.map(async region => {}` in `houseKeeping.sweep()`. Instead, we would go through each region within `_sweepVolumes()` and we would then be able to return an object in the requested form.

## Tests
I have not implemented any tests for this PR but all of the previously implemented tests pass.

In the test, "should call `_handleVolumeData `exactly once per volume", `houseKeeper.sweep()` does call `_handleVolumeData()` twice (since we described two volumes) but appears to be taking the default empty `describeVolumeStub` (not any of the stub arguments that are returned in the test).

When I print out the `outcomeInfo`, no volume totals are returned. When I move `houseKeeperMock.expects("_handleVolumeData").twice();` to after `houseKeeper.sweep()`, `outcomeInfo` does get the correct totals. In this case, Sinon wouldn't see that `_handleVolumeData()` is called twice so the test would fail. 

## Questions
In the third PR, we are going to be implementing a function that takes these totals and submits them to the correct statsum series (e.g. unused-gb-usage vs. gb-usage). I'm thinking `_sweepVolumes()` should actually return an object where these totals are categorized by region, type, and **status**.

`_handleVolumeData()` could probably be refactored out and combined with `_calculateTotals`.