### PR TITLE
Paginate AWS results, submit total GB usage and volume count to appropriate statsum series

### DIFF
--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -67,6 +67,8 @@ class HouseKeeper {
     //   ...
     // }
 
+    let volumesMonitor = this.monitor.prefix('ebs-volumes');
+
     //assert(typeof totalsByCategory === 'object');
 
     // Keep track of overall totals, over all regions
@@ -93,8 +95,8 @@ class HouseKeeper {
         //assert(active.hasOwnProperty('gb'));
         //assert(active.hasOwnProperty('count'));
 
-        this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
-        this.monitor.count('ebs-volumes:${region}:count', active.count);
+        volumesMonitor.measure('${region}.gb-usage', active.gb);
+        volumesMonitor.measure('${region}.count', active.count);
         totalGbUsage += active.gb;
         totalCount += active.count;
 
@@ -102,20 +104,19 @@ class HouseKeeper {
         //assert(unused.hasOwnProperty('gb'));
         //assert(unused.hasOwnProperty('count'));
 
-        this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
-        this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+        volumesMonitor.measure('${region}.unused-gb-usage', unused.gb);
+        volumesMonitor.measure('${region}.unused-count', unused.count);
         totalGbUsage += unused.gb;
         totalCount += unused.count;
 
-        this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
-        this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
+        volumesMonitor.measure('${region}.${type}.gb-usage', active.gb + unused.gb);
+        volumesMonitor.measure('${region}.${type}.count', active.count + unused.count);
       })
     })
     
     // Update global totals after all regions have been processed
-    this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
-    this.monitor.count('ebs-volumes:global:count', totalCount);
-
+    volumesMonitor.measure('global.gb-usage', totalGbUsage);
+    volumesMonitor.measure('global.count', totalCount);
   }
 
   _handleVolumeData(volumes) {

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -77,7 +77,7 @@ class HouseKeeper {
     // Assumption:
     // totalsByCategory is organized as follows:
     // { 
-    //   ${region}: [ 
+    //   ${region}:  
     //     {
     //       ${vol-type}: {
     //         active: {
@@ -88,19 +88,19 @@ class HouseKeeper {
     //           gb: value,
     //           count: value
     //         }
-    //       }
+    //       },
+    //       ...
     //     },
+    //   ${region}: 
+    //     {
     //     ...
-    //   ],
-    //   ${region} : [
-    //   ...
-    //   ],
+    //     },
     //   ...
     // }
 
     let volumesMonitor = this.monitor.prefix('ebs-volumes');
 
-    //assert(typeof totalsByCategory === 'object');
+    assert(typeof totalsByCategory === 'object');
 
     // Keep track of overall totals, over all regions
     let totalGbUsage = 0;
@@ -109,29 +109,28 @@ class HouseKeeper {
     Object.keys(totalsByCategory).forEach(region => {
   
       let volumeTypes = totalsByCategory[region];
-      //assert(typeof volumeTypes === 'object');
-      //assert(typeof volumeTypes.hasOwnProperty('length'));
+      assert(typeof volumeTypes === 'object');
 
       Object.keys(volumeTypes).forEach(type => {
-        //assert(typeof type === 'object');
+        assert(typeof type === 'string');
 
-        //assert(data.hasOwnProperty('active'));
-        //assert(data.hasOwnProperty('unused'));
-        let active = volumeTypes[type]['active'];
-        let unused = volumeTypes[type]['unused'];
+        let statuses = volumeTypes[type];
+        assert(statuses.hasOwnProperty('active'));
+        assert(statuses.hasOwnProperty('unused'));
+        let {active, unused} = statuses;
 
-        //assert(typeof active === 'object');
-        //assert(active.hasOwnProperty('gb'));
-        //assert(active.hasOwnProperty('count'));
+        assert(typeof active === 'object');
+        assert(active.hasOwnProperty('gb'));
+        assert(active.hasOwnProperty('count'));
 
         volumesMonitor.measure('${region}.gb-usage', active.gb);
         volumesMonitor.measure('${region}.count', active.count);
         totalGbUsage += active.gb;
         totalCount += active.count;
 
-        //assert(typeof unused === 'object');
-        //assert(unused.hasOwnProperty('gb'));
-        //assert(unused.hasOwnProperty('count'));
+        assert(typeof unused === 'object');
+        assert(unused.hasOwnProperty('gb'));
+        assert(unused.hasOwnProperty('count'));
 
         volumesMonitor.measure('${region}.unused-gb-usage', unused.gb);
         volumesMonitor.measure('${region}.unused-count', unused.count);

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -109,8 +109,8 @@ class HouseKeeper {
         totalGbUsage += unused.gb;
         totalCount += unused.count;
 
-        volumesMonitor.measure('${region}.${type}.gb-usage', active.gb + unused.gb);
-        volumesMonitor.measure('${region}.${type}.count', active.count + unused.count);
+        volumesMonitor.measure('${region}.type:${type}.gb-usage', active.gb + unused.gb);
+        volumesMonitor.measure('${region}.type:${type}.count', active.count + unused.count);
       })
     })
     

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -367,9 +367,9 @@ describe('House Keeper', () => {
         AvailabilityZone: 'us-west-2', 
         CreateTime: new Date().toString(), 
         Size: 8, 
-        SnapshotId: "snap-1234567890abcdef0", 
+        SnapshotId: "snap-1234567890abcdef9", 
         State: "in-use", 
-        VolumeId: "vol-049df61146c4d7901", 
+        VolumeId: "vol-049df61146c4d7902", 
         VolumeType: "standard",
       }],
       NextToken: null


### PR DESCRIPTION
### Code Changes

The following code relies on @SamanthaYu's ongoing work on calculating the total GB usage and volume count in each region, separated by volume type and status (see [https://github.com/rstiyer/ec2-manager/pull/1](url)).

First of all, I modified the AWS API call to request paginated data. The max page size is 500, and I don't see any reason not to use the maximum size. The 'describeVolumes' endpoint appears to return all data if you don't specify a page size, but we don't want to rely on this since many other endpoints only return the max page size.

Second, I changed our approach with `_handleVolumeData(...)`. Previously, we called the function for every individual volume, but that doesn't make very much sense since we really care about the aggregation of all volumes within the region. Instead, I changed its parameter to be the list of all volumes in the region. This function now calls our helper functions for calculating and updating the totals per region, `_calculateVolumeTotals` and `_updateVolumeTotals`. I added 'volume' to the name of these functions to differentiate these functions from those that will eventually be added to complete similar functionality for the instance and spot request endpoints. I thought it made sense to have these helper calls in `_handleVolumeData` to encourage the single-responsibility principle.

Finally, I created a preliminary implementation of `_updateVolumeTotals`. This takes one parameter: an object containing the required values returned by `_calculateVolumeTotals`. It extracts the relevant information and then updates the count of appropriate statsum series. I added a bunch of asset statements (which are now commented out) to ensure that incorrect data is not accidentally submitted to the statsum series.

### Questions:
* It may take more than 90 seconds for `_sweepVolumes` to complete for the real data, which means that the 'global' updates might not all be aggregated together in the same 5 minute period. We can't test this ourselves, unfortunately. If this is indeed the case, we'll have to store the overall totals and update the 'global' series after processing every region.