### PR TITLE
Calculate EBS volume totals by region, type, and whether it's unused/active

### DIFF
--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -37,8 +37,41 @@ class HouseKeeper {
     this.monitor = monitor;
     this.tagger = tagger;
   }
+  
+  _calculateTotals(volumesByType) {
+    let totalVolumes = new Object();
+    
+    volumesByType.forEach(function(volume) {
+      if (typeof volume != 'undefined') {
+        let totalDataPerType;
+        
+        if (volume.VolumeType in totalVolumes) {
+          totalDataPerType = new Object();
+          totalDataPerType['count'] = 1;
+          totalDataPerType['gb'] = volume.Size;
+        }
+        else {
+          totalDataPerType = totalVolumes[volume.VolumeType];
+          totalDataPerType['count']++;
+          totalDataPerType['gb'] += volume.Size;
+        }
+        totalVolumes[volume.VolumeType] = totalDataPerType;
+      }
+    });
+    
+    return totalVolumes;
+  }
 
-  async _handleVolumeData(volume) {}
+  // Tabulate the required data
+  async _handleVolumeData(volume) {
+    return new Promise((resolve, reject) => {
+      let volumeData = {};
+      volumeData['type'] = volume.VolumeType;
+      volumeData['size'] = volume.Size;
+      volumeData['status'] = volume.State;
+      resolve(volumeData);
+    });
+  }
 
   async _sweepVolumes(region) {
     let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
@@ -48,7 +81,8 @@ class HouseKeeper {
       }],
     });
 
-    await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    let volumesByType = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    return this._calculateTotals(volumesByType);
   }
 
   async sweep() {
@@ -80,7 +114,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      await this._sweepVolumes(region);
+      let totalVolumes = await this._sweepVolumes(region);
 
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -38,7 +38,9 @@ class HouseKeeper {
     this.tagger = tagger;
   }
 
-  _calculateVolumeTotals(volumes) {}
+  _calculateVolumeTotals(volumes) {
+    return {};
+  }
 
   _submitVolumeTotals(totalsByCategory) {
     // Assumption:
@@ -147,7 +149,6 @@ class HouseKeeper {
     } while (nextToken != null)
 
     return volumes;
-
     
   }
 
@@ -380,6 +381,8 @@ class HouseKeeper {
 
     }));
 
+    // Calculate totals and update statum series after all regions' volume data
+    // has been accumulated.
     this._handleVolumeData(volumesByRegion);
 
     log.info(outcomeInfo, 'Housekeeping is finished');

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -63,11 +63,11 @@ class HouseKeeper {
         }
         
         if (volume.State === 'available') {
-          totalVolumes[region][type]['unused']['count'] = totalVolumes[region][type]['unused']['count'] + 1;
-          totalVolumes[region][type]['unused']['gb'] = totalVolumes[region][type]['unused']['gb'] + volume.Size;
+          totalVolumes[region][type]['unused']['count'] += 1;
+          totalVolumes[region][type]['unused']['gb'] += volume.Size;
         } else if (volume.State === 'in-use') {
-          totalVolumes[region][type]['active']['count'] = totalVolumes[region][type]['active']['count'] + 1;
-          totalVolumes[region][type]['active']['gb'] = totalVolumes[region][type]['active']['gb'] + volume.Size;
+          totalVolumes[region][type]['active']['count'] += 1;
+          totalVolumes[region][type]['active']['gb'] += volume.Size;
         }
       });
     });
@@ -123,9 +123,8 @@ class HouseKeeper {
         //assert(typeof active === 'object');
         //assert(active.hasOwnProperty('gb'));
         //assert(active.hasOwnProperty('count'));
-
-        this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
-        this.monitor.count('ebs-volumes:${region}:count', active.count);
+        monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
+        monitor.count('ebs-volumes:${region}:count', active.count);
         totalGbUsage += active.gb;
         totalCount += active.count;
 
@@ -133,13 +132,13 @@ class HouseKeeper {
         //assert(unused.hasOwnProperty('gb'));
         //assert(unused.hasOwnProperty('count'));
 
-        this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
-        this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+        monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
+        monitor.count('ebs-volumes:${region}:unused-count', unused.count);
         totalGbUsage += unused.gb;
         totalCount += unused.count;
 
-        this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
-        this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
+        monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
+        monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
       });
     });
   

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -296,7 +296,6 @@ class HouseKeeper {
 
 
       outcomeInfo[region] = {
-        volumes: totalVolumes,
         state: {
           missingRequests,
           missingInstances,

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -55,7 +55,6 @@ class HouseKeeper {
             gb: volume.size,
           };
         }
-
       }
     });
     
@@ -64,10 +63,11 @@ class HouseKeeper {
 
   // Tabulate the required data
   async _handleVolumeData(volume) {
-    let volumeData = {};
-    volumeData['type'] = volume.VolumeType;
-    volumeData['size'] = volume.Size;
-    volumeData['status'] = volume.State;
+    let volumeData = {
+      type: volume.VolumeType,
+      size: volume.Size,
+      status: volume.State,
+    };
 
     return new Promise((resolve, reject) => {
       resolve(volumeData);
@@ -116,7 +116,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      let totalVolumes = await this._sweepVolumes(region)    
+      let totalVolumes = await this._sweepVolumes(region);
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{
           Name: 'key-name',

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -64,11 +64,12 @@ class HouseKeeper {
 
   // Tabulate the required data
   async _handleVolumeData(volume) {
+    let volumeData = {};
+    volumeData['type'] = volume.VolumeType;
+    volumeData['size'] = volume.Size;
+    volumeData['status'] = volume.State;
+
     return new Promise((resolve, reject) => {
-      let volumeData = {};
-      volumeData['type'] = volume.VolumeType;
-      volumeData['size'] = volume.Size;
-      volumeData['status'] = volume.State;
       resolve(volumeData);
     });
   }
@@ -81,7 +82,7 @@ class HouseKeeper {
       }],
     });
 
-    let volumesByType = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    let volumesByType = await Promise.all(volumes.Volumes.map(volume => this._handleVolumeData(volume)));
     return this._calculateTotals(volumesByType);
   }
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -61,36 +61,36 @@ class HouseKeeper {
     //   ]
     // }
 
-    assert(typeof totalsByCategory === 'object');
+    //assert(typeof totalsByCategory === 'object');
 
-    assert(Object.keys(totalsByCategory).length === 1);
+    //assert(Object.keys(totalsByCategory).length === 1);
     let region =  Object.keys(totalsByCategory)[0];
     
     let volumeTypes = totalsByCategory[region];
-    assert(typeof volumeTypes === 'object');
-    assert(typeof volumeTypes.hasOwnProperty('length'));
+    //assert(typeof volumeTypes === 'object');
+    //assert(typeof volumeTypes.hasOwnProperty('length'));
 
     volumeTypes.forEach(function(data) {
-      assert(typeof data === 'object');
+      //assert(typeof data === 'object');
       
-      assert(Object.keys(data).length === 1);
+      //assert(Object.keys(data).length === 1);
       let type = Object.keys(data)[0];
 
-      assert(data.hasOwnProperty('active'));
-      assert(data.hasOwnProperty('unused'));
+      //assert(data.hasOwnProperty('active'));
+      //assert(data.hasOwnProperty('unused'));
       let active = data.active;
       let unused = data.unused;
 
-      assert(typeof active === 'object');
-      assert(active.hasOwnProperty('gb'));
-      assert(active.hasOwnProperty('count'));
+      //assert(typeof active === 'object');
+      //assert(active.hasOwnProperty('gb'));
+      //assert(active.hasOwnProperty('count'));
 
       this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
       this.monitor.count('ebs-volumes:${region}:count', active.count);
 
-      assert(typeof unused === 'object');
-      assert(unused.hasOwnProperty('gb'));
-      assert(unused.hasOwnProperty('count'));
+      //assert(typeof unused === 'object');
+      //assert(unused.hasOwnProperty('gb'));
+      //assert(unused.hasOwnProperty('count'));
 
       this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
       this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
@@ -137,7 +137,10 @@ class HouseKeeper {
     }
 
     // After accumlating all of the volumes returned by AWS, process the results.
-    this._handleVolumeData(volumes);
+    // However, we should only bother processing if this region actually has any volumes.
+    if (volumes.length > 0) {
+      this._handleVolumeData(volumes);
+    }
   }
 
   async sweep() {

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -58,7 +58,11 @@ class HouseKeeper {
     //       }
     //     },
     //     ...
-    //   ]
+    //   ],
+    //   ${region} : [
+    //   ...
+    //   ],
+    //   ...
     // }
 
     //assert(typeof totalsByCategory === 'object');
@@ -104,7 +108,7 @@ class HouseKeeper {
 }
 
   _handleVolumeData(volumes) {
-    // First, calculate total GBs and volumes by category
+    // First, calculate total GBs and volumes by region and category
     let totals = this._calculateVolumeTotals(volumes);
 
     // Now, send an update to each corresponding statsum series with current totals.
@@ -133,11 +137,9 @@ class HouseKeeper {
       nextToken = awsResults.NextToken;
     } while (nextToken != null)
 
-    // After accumlating all of the volumes returned by AWS, process the results.
-    // However, we should only bother processing if this region actually has any volumes.
-    if (volumes.length > 0) {
-      this._handleVolumeData(volumes);
-    }
+    return volumes;
+
+    
   }
 
   async sweep() {
@@ -156,6 +158,7 @@ class HouseKeeper {
     killIfOlder.setHours(killIfOlder.getHours() - this.maxInstanceLifeHours);
 
     let outcomeInfo = {};
+    let volumesByRegion = {};
 
     // We want to do housekeeping for each region independently.
     await Promise.all(this.regions.map(async region => {
@@ -169,7 +172,13 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      await this._sweepVolumes(region);
+      let volumes = await this._sweepVolumes(region);
+      // After accumlating all of the volumes in this region returned by AWS, add them to
+      // the volumesByRegion dictionary. However, we should only bother processing if this
+      // region actually has any volumes.
+      if (volumes.length > 0) {
+        volumesByRegion[region] = volumes;
+      }
 
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{
@@ -361,6 +370,8 @@ class HouseKeeper {
       };
 
     }));
+
+    _handleVolumeData(volumesyRegion);
 
     log.info(outcomeInfo, 'Housekeeping is finished');
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -42,11 +42,11 @@ class HouseKeeper {
   _calculateVolumeTotals(tabulatedVolumes) {
     let totalVolumes = {};
     
-    Object.keys(tabulatedVolumes).forEach(function(region) {
+    Object.keys(tabulatedVolumes).forEach(region => {
       // Initialize totals for each region
       totalVolumes[region] = {};
       
-      tabulatedVolumes[region].forEach(function(volume) {
+      tabulatedVolumes[region].forEach(volume => {
         let type = volume.VolumeType;
         
         if (!(type in totalVolumes[region])) {
@@ -104,13 +104,13 @@ class HouseKeeper {
     let totalGbUsage = 0;
     let totalCount = 0;
     
-    Object.keys(totalsByCategory).forEach(function(region) {
+    Object.keys(totalsByCategory).forEach(region => {
   
       let volumeTypes = totalsByCategory[region];
       //assert(typeof volumeTypes === 'object');
       //assert(typeof volumeTypes.hasOwnProperty('length'));
 
-      Object.keys(volumeTypes).forEach(function(type) {
+      Object.keys(volumeTypes).forEach(type => {
         //assert(typeof type === 'object');
 
         //assert(data.hasOwnProperty('active'));
@@ -121,8 +121,8 @@ class HouseKeeper {
         //assert(typeof active === 'object');
         //assert(active.hasOwnProperty('gb'));
         //assert(active.hasOwnProperty('count'));
-        monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
-        monitor.count('ebs-volumes:${region}:count', active.count);
+        this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
+        this.monitor.count('ebs-volumes:${region}:count', active.count);
         totalGbUsage += active.gb;
         totalCount += active.count;
 
@@ -130,13 +130,13 @@ class HouseKeeper {
         //assert(unused.hasOwnProperty('gb'));
         //assert(unused.hasOwnProperty('count'));
 
-        monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
-        monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+        this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
+        this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
         totalGbUsage += unused.gb;
         totalCount += unused.count;
 
-        monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
-        monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
+        this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
+        this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
       });
     });
   

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -67,45 +67,54 @@ class HouseKeeper {
 
     //assert(typeof totalsByCategory === 'object');
 
-    //assert(Object.keys(totalsByCategory).length === 1);
-    let region =  Object.keys(totalsByCategory)[0];
+    // Keep track of overall totals, over all regions
+    let totalGbUsage = 0;
+    let totalCount = 0;
+
+    Object.keys(totalsByCategory).forEach(function(region) {
     
-    let volumeTypes = totalsByCategory[region];
-    //assert(typeof volumeTypes === 'object');
-    //assert(typeof volumeTypes.hasOwnProperty('length'));
+      let volumeTypes = totalsByCategory[region];
+      //assert(typeof volumeTypes === 'object');
+      //assert(typeof volumeTypes.hasOwnProperty('length'));
 
-    volumeTypes.forEach(function(data) {
-      //assert(typeof data === 'object');
+      volumeTypes.forEach(function(data) {
+        //assert(typeof data === 'object');
       
-      //assert(Object.keys(data).length === 1);
-      let type = Object.keys(data)[0];
+        //assert(Object.keys(data).length === 1);
+        let type = Object.keys(data)[0];
 
-      //assert(data.hasOwnProperty('active'));
-      //assert(data.hasOwnProperty('unused'));
-      let {active, unused} = data;
+        //assert(data.hasOwnProperty('active'));
+        //assert(data.hasOwnProperty('unused'));
+        let {active, unused} = data;
 
-      //assert(typeof active === 'object');
-      //assert(active.hasOwnProperty('gb'));
-      //assert(active.hasOwnProperty('count'));
+        //assert(typeof active === 'object');
+        //assert(active.hasOwnProperty('gb'));
+        //assert(active.hasOwnProperty('count'));
 
-      this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
-      this.monitor.count('ebs-volumes:${region}:count', active.count);
+        this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
+        this.monitor.count('ebs-volumes:${region}:count', active.count);
+        totalGbUsage += active.gb;
+        totalCount += active.count;
 
-      //assert(typeof unused === 'object');
-      //assert(unused.hasOwnProperty('gb'));
-      //assert(unused.hasOwnProperty('count'));
+        //assert(typeof unused === 'object');
+        //assert(unused.hasOwnProperty('gb'));
+        //assert(unused.hasOwnProperty('count'));
 
-      this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
-      this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+        this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
+        this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+        totalGbUsage += unused.gb;
+        totalCount += unused.count;
 
-      let totalGbUsage = active.gb + unused.gb;
-      let totalCount = active.count + unused.count;
-      this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
-      this.monitor.count('ebs-volumes:global:count', totalCount);
-      this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', totalGbUsage);
-      this.monitor.count('ebs-volumes:${region}:type:${type}:count', totalCount);
+        this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
+        this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
+      })
     })
-}
+    
+    // Update global totals after all regions have been processed
+    this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
+    this.monitor.count('ebs-volumes:global:count', totalCount);
+
+  }
 
   _handleVolumeData(volumes) {
     // First, calculate total GBs and volumes by region and category
@@ -371,7 +380,7 @@ class HouseKeeper {
 
     }));
 
-    _handleVolumeData(volumesyRegion);
+    this._handleVolumeData(volumesByRegion);
 
     log.info(outcomeInfo, 'Housekeeping is finished');
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -38,24 +38,24 @@ class HouseKeeper {
     this.tagger = tagger;
   }
   
-  _calculateTotals(volumesByType) {
-    let totalVolumes = new Object();
+  _calculateTotals(tabulatedVolumes) {
+    let totalVolumes = {};
     
-    volumesByType.forEach(function(volume) {
+    tabulatedVolumes.forEach(function(volume) {
       if (typeof volume != 'undefined') {
-        let totalDataPerType;
-        
-        if (volume.VolumeType in totalVolumes) {
-          totalDataPerType = new Object();
-          totalDataPerType['count'] = 1;
-          totalDataPerType['gb'] = volume.Size;
+        if (volume.type in totalVolumes) {
+          totalVolumes[volume.type] = {
+            count: totalVolumes[volume.type]['count'] + 1,
+            gb: totalVolumes[volume.type]['gb'] += volume.size,
+          };
         }
         else {
-          totalDataPerType = totalVolumes[volume.VolumeType];
-          totalDataPerType['count']++;
-          totalDataPerType['gb'] += volume.Size;
+          totalVolumes[volume.type] = {
+            count: 1,
+            gb: volume.size,
+          };
         }
-        totalVolumes[volume.VolumeType] = totalDataPerType;
+
       }
     });
     
@@ -81,9 +81,10 @@ class HouseKeeper {
         Values: ['available', 'in-use'],
       }],
     });
-
-    let volumesByType = await Promise.all(volumes.Volumes.map(volume => this._handleVolumeData(volume)));
-    return this._calculateTotals(volumesByType);
+    
+    let tabulatedVolumes = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    let totalVolumes = this._calculateTotals(tabulatedVolumes);
+    return totalVolumes;
   }
 
   async sweep() {
@@ -115,8 +116,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      let totalVolumes = await this._sweepVolumes(region);
-
+      let totalVolumes = await this._sweepVolumes(region)    
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{
           Name: 'key-name',
@@ -297,6 +297,7 @@ class HouseKeeper {
 
 
       outcomeInfo[region] = {
+        volumes: totalVolumes,
         state: {
           missingRequests,
           missingInstances,

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -41,12 +41,27 @@ class HouseKeeper {
   async _handleVolumeData(volume) {}
 
   async _sweepVolumes(region) {
-    let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
-      Filters: [{
-        Name: 'status',
-        Values: ['available', 'in-use'],
-      }],
-    });
+    // Collect all volume objects returned from AWS in a single array
+    let volumes = []
+
+    // We need to keep track of the NextToken value returned by AWS. Its value is non-null
+    // if the number of entries in AWS exceeds MaxResults and the next page can be retrieved
+    // by specifying NextToken in a subsequent request.
+    let hasNextToken = true;
+    let nextToken = null;
+    while (hasNextToken) {
+      let awsResults = await this.runaws(this.ec2[region], 'describeVolumes', {
+        Filters: [{
+          Name: 'status',
+          Values: ['available', 'in-use'],
+        }],
+        MaxResults: 100,
+        NextToken: nextToken
+      });
+
+      volumes = volumes.concat(awsResults.Volumes);
+      nextToken = awsResults.NextToken;
+    }
 
     await Promise.all(volumes.Volumes.map(this._handleVolumeData));
   }

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -78,8 +78,7 @@ class HouseKeeper {
 
       //assert(data.hasOwnProperty('active'));
       //assert(data.hasOwnProperty('unused'));
-      let active = data.active;
-      let unused = data.unused;
+      let {active, unused} = data;
 
       //assert(typeof active === 'object');
       //assert(active.hasOwnProperty('gb'));
@@ -119,9 +118,8 @@ class HouseKeeper {
     // We need to keep track of the NextToken value returned by AWS. Its value is non-null
     // if the number of entries in AWS exceeds MaxResults and the next page can be retrieved
     // by specifying NextToken in a subsequent request.
-    let hasNextToken = true;
     let nextToken = null;
-    while (hasNextToken) {
+    do {
       let awsResults = await this.runaws(this.ec2[region], 'describeVolumes', {
         Filters: [{
           Name: 'status',
@@ -133,8 +131,7 @@ class HouseKeeper {
 
       volumes = volumes.concat(awsResults.Volumes);
       nextToken = awsResults.NextToken;
-      hasNextToken = (nextToken != null)
-    }
+    } while (nextToken != null)
 
     // After accumlating all of the volumes returned by AWS, process the results.
     // However, we should only bother processing if this region actually has any volumes.

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const {runAWSRequest} = require('./aws-request');
+const util = require('util');
 
 const log = require('./log');
 
@@ -41,32 +42,32 @@ class HouseKeeper {
   _calculateVolumeTotals(tabulatedVolumes) {
     let totalVolumes = {};
     
-    Object.keys(tabulatedVolumes).forEach(function(volume) {
-      if (typeof volume != 'undefined') {
-        if (volume.type in totalVolumes) {
-          totalVolumes[volume.type] = {
-            count: totalVolumes[volume.type]['count'] + 1,
-            gb: totalVolumes[volume.type]['gb'] += volume.size,
-          };
-        } else {
-          totalVolumes[volume.type] = {
-            count: 1,
-            gb: volume.size,
-          };
+    Object.keys(tabulatedVolumes).forEach(function(volumesInRegion) {
+      tabulatedVolumes[volumesInRegion].forEach(function(volume) {        
+        let region = volume.AvailabilityZone;
+        
+        if (!(region in totalVolumes)) {
+          totalVolumes[region] = {};
+          totalVolumes[region]['active'] = {};
+          totalVolumes[region]['unused'] = {};
+          
+          totalVolumes[region]['active']['count'] = 0;
+          totalVolumes[region]['active']['gb'] = 0;
+          totalVolumes[region]['unused']['count'] = 0;
+          totalVolumes[region]['unused']['gb'] = 0;
         }
-      }
+        
+        if (volume.State === 'available') {
+          totalVolumes[region]['unused']['count'] = totalVolumes[region]['unused']['count'] + 1;
+          totalVolumes[region]['unused']['gb'] = totalVolumes[region]['unused']['gb'] + volume.Size;
+        } else if (volume.State === 'in-use') {
+          totalVolumes[region]['active']['count'] = totalVolumes[region]['active']['count'] + 1;
+          totalVolumes[region]['active']['gb'] = totalVolumes[region]['active']['gb'] + volume.Size;
+        }
+      });
     });
     
     return totalVolumes;
-  }
-
-  // Tabulate the required data
-  async _handleVolumeData(volume) {
-    let volumeData = {
-      type: volume.VolumeType,
-      size: volume.Size,
-      status: volume.State,
-    };
   }
 
   _submitVolumeTotals(totalsByCategory) {
@@ -99,49 +100,41 @@ class HouseKeeper {
     // Keep track of overall totals, over all regions
     let totalGbUsage = 0;
     let totalCount = 0;
-
+    
     Object.keys(totalsByCategory).forEach(function(region) {
     
       let volumeTypes = totalsByCategory[region];
       //assert(typeof volumeTypes === 'object');
       //assert(typeof volumeTypes.hasOwnProperty('length'));
 
-      volumeTypes.forEach(function(data) {
-        //assert(typeof data === 'object');
-      
-        //assert(Object.keys(data).length === 1);
-        let type = Object.keys(data)[0];
+      //assert(data.hasOwnProperty('active'));
+      //assert(data.hasOwnProperty('unused'));
 
-        //assert(data.hasOwnProperty('active'));
-        //assert(data.hasOwnProperty('unused'));
-        let {active, unused} = data;
+      //assert(typeof active === 'object');
+      //assert(active.hasOwnProperty('gb'));
+      //assert(active.hasOwnProperty('count'));
 
-        //assert(typeof active === 'object');
-        //assert(active.hasOwnProperty('gb'));
-        //assert(active.hasOwnProperty('count'));
+      //this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
+      //this.monitor.count('ebs-volumes:${region}:count', active.count);
+      totalGbUsage += volumeTypes['active']['gb'];
+      totalCount += volumeTypes['active']['count'];
 
-        this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
-        this.monitor.count('ebs-volumes:${region}:count', active.count);
-        totalGbUsage += active.gb;
-        totalCount += active.count;
+      //assert(typeof unused === 'object');
+      //assert(unused.hasOwnProperty('gb'));
+      //assert(unused.hasOwnProperty('count'));
 
-        //assert(typeof unused === 'object');
-        //assert(unused.hasOwnProperty('gb'));
-        //assert(unused.hasOwnProperty('count'));
+      //this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
+      //this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+      totalGbUsage += volumeTypes['unused']['gb'];
+      totalCount += volumeTypes['unused']['count'];
 
-        this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
-        this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
-        totalGbUsage += unused.gb;
-        totalCount += unused.count;
-
-        this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
-        this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
-      });
+      //this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
+      //this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
     });
     
     // Update global totals after all regions have been processed
-    this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
-    this.monitor.count('ebs-volumes:global:count', totalCount);
+    //this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
+    //this.monitor.count('ebs-volumes:global:count', totalCount);
 
   }
 
@@ -410,7 +403,7 @@ class HouseKeeper {
     // Calculate totals and update statum series after all regions' volume data
     // has been accumulated.
     this._handleVolumeData(volumesByRegion);
-
+    
     log.info(outcomeInfo, 'Housekeeping is finished');
 
     // Only returning for unit testing

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -48,8 +48,7 @@ class HouseKeeper {
             count: totalVolumes[volume.type]['count'] + 1,
             gb: totalVolumes[volume.type]['gb'] += volume.size,
           };
-        }
-        else {
+        } else {
           totalVolumes[volume.type] = {
             count: 1,
             gb: volume.size,

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -45,24 +45,29 @@ class HouseKeeper {
     Object.keys(tabulatedVolumes).forEach(function(volumesInRegion) {
       tabulatedVolumes[volumesInRegion].forEach(function(volume) {        
         let region = volume.AvailabilityZone;
+        let type = volume.VolumeType;
         
         if (!(region in totalVolumes)) {
           totalVolumes[region] = {};
-          totalVolumes[region]['active'] = {};
-          totalVolumes[region]['unused'] = {};
+        }
+        
+        if (!(type in totalVolumes[region])) {
+          totalVolumes[region][type] = {};
+          totalVolumes[region][type]['active'] = {};
+          totalVolumes[region][type]['unused'] = {};
           
-          totalVolumes[region]['active']['count'] = 0;
-          totalVolumes[region]['active']['gb'] = 0;
-          totalVolumes[region]['unused']['count'] = 0;
-          totalVolumes[region]['unused']['gb'] = 0;
+          totalVolumes[region][type]['active']['count'] = 0;
+          totalVolumes[region][type]['active']['gb'] = 0;
+          totalVolumes[region][type]['unused']['count'] = 0;
+          totalVolumes[region][type]['unused']['gb'] = 0;
         }
         
         if (volume.State === 'available') {
-          totalVolumes[region]['unused']['count'] = totalVolumes[region]['unused']['count'] + 1;
-          totalVolumes[region]['unused']['gb'] = totalVolumes[region]['unused']['gb'] + volume.Size;
+          totalVolumes[region][type]['unused']['count'] = totalVolumes[region][type]['unused']['count'] + 1;
+          totalVolumes[region][type]['unused']['gb'] = totalVolumes[region][type]['unused']['gb'] + volume.Size;
         } else if (volume.State === 'in-use') {
-          totalVolumes[region]['active']['count'] = totalVolumes[region]['active']['count'] + 1;
-          totalVolumes[region]['active']['gb'] = totalVolumes[region]['active']['gb'] + volume.Size;
+          totalVolumes[region][type]['active']['count'] = totalVolumes[region][type]['active']['count'] + 1;
+          totalVolumes[region][type]['active']['gb'] = totalVolumes[region][type]['active']['gb'] + volume.Size;
         }
       });
     });
@@ -102,39 +107,45 @@ class HouseKeeper {
     let totalCount = 0;
     
     Object.keys(totalsByCategory).forEach(function(region) {
-    
+  
       let volumeTypes = totalsByCategory[region];
       //assert(typeof volumeTypes === 'object');
       //assert(typeof volumeTypes.hasOwnProperty('length'));
 
-      //assert(data.hasOwnProperty('active'));
-      //assert(data.hasOwnProperty('unused'));
+      Object.keys(volumeTypes).forEach(function(type) {
+        //assert(typeof type === 'object');
 
-      //assert(typeof active === 'object');
-      //assert(active.hasOwnProperty('gb'));
-      //assert(active.hasOwnProperty('count'));
+        //assert(data.hasOwnProperty('active'));
+        //assert(data.hasOwnProperty('unused'));
+        let active = volumeTypes[type]['active'];
+        let unused = volumeTypes[type]['unused'];
 
-      //this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
-      //this.monitor.count('ebs-volumes:${region}:count', active.count);
-      totalGbUsage += volumeTypes['active']['gb'];
-      totalCount += volumeTypes['active']['count'];
+        //assert(typeof active === 'object');
+        //assert(active.hasOwnProperty('gb'));
+        //assert(active.hasOwnProperty('count'));
 
-      //assert(typeof unused === 'object');
-      //assert(unused.hasOwnProperty('gb'));
-      //assert(unused.hasOwnProperty('count'));
+        this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
+        this.monitor.count('ebs-volumes:${region}:count', active.count);
+        totalGbUsage += active.gb;
+        totalCount += active.count;
 
-      //this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
-      //this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
-      totalGbUsage += volumeTypes['unused']['gb'];
-      totalCount += volumeTypes['unused']['count'];
+        //assert(typeof unused === 'object');
+        //assert(unused.hasOwnProperty('gb'));
+        //assert(unused.hasOwnProperty('count'));
 
-      //this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
-      //this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
+        this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
+        this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+        totalGbUsage += unused.gb;
+        totalCount += unused.count;
+
+        this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', active.gb + unused.gb);
+        this.monitor.count('ebs-volumes:${region}:type:${type}:count', active.count + unused.count);
+      });
     });
-    
+  
     // Update global totals after all regions have been processed
-    //this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
-    //this.monitor.count('ebs-volumes:global:count', totalCount);
+    this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
+    this.monitor.count('ebs-volumes:global:count', totalCount);
 
   }
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -40,7 +40,69 @@ class HouseKeeper {
 
   _calculateVolumeTotals(volumes) {}
 
-  _submitVolumeTotals(totalsByCategory) {}
+  _submitVolumeTotals(totalsByCategory) {
+    // Assumption:
+    // totalsByCategory is organized as follows:
+    // { 
+    //   ${region}: [ 
+    //     {
+    //       ${vol-type}: {
+    //         active: {
+    //           gb: value,
+    //           count: value
+    //         },
+    //         unused: {
+    //           gb: value,
+    //           count: value
+    //         }
+    //       }
+    //     },
+    //     ...
+    //   ]
+    // }
+
+    assert(typeof totalsByCategory === 'object');
+
+    assert(Object.keys(totalsByCategory).length === 1);
+    let region =  Object.keys(totalsByCategory)[0];
+    
+    let volumeTypes = totalsByCategory[region];
+    assert(typeof volumeTypes === 'object');
+    assert(typeof volumeTypes.hasOwnProperty('length'));
+
+    volumeTypes.forEach(function(data) {
+      assert(typeof data === 'object');
+      
+      assert(Object.keys(data).length === 1);
+      let type = Object.keys(data)[0];
+
+      assert(data.hasOwnProperty('active'));
+      assert(data.hasOwnProperty('unused'));
+      let active = data.active;
+      let unused = data.unused;
+
+      assert(typeof active === 'object');
+      assert(active.hasOwnProperty('gb'));
+      assert(active.hasOwnProperty('count'));
+
+      this.monitor.count('ebs-volumes:${region}:gb-usage', active.gb);
+      this.monitor.count('ebs-volumes:${region}:count', active.count);
+
+      assert(typeof unused === 'object');
+      assert(unused.hasOwnProperty('gb'));
+      assert(unused.hasOwnProperty('count'));
+
+      this.monitor.count('ebs-volumes:${region}:unused-gb-usage', unused.gb);
+      this.monitor.count('ebs-volumes:${region}:unused-count', unused.count);
+
+      let totalGbUsage = active.gb + unused.gb;
+      let totalCount = active.count + unused.count;
+      this.monitor.count('ebs-volumes:global:gb-usage', totalGbUsage);
+      this.monitor.count('ebs-volumes:global:count', totalCount);
+      this.monitor.count('ebs-volumes:${region}:type:${type}:gb-usage', totalGbUsage);
+      this.monitor.count('ebs-volumes:${region}:type:${type}:count', totalCount);
+    })
+}
 
   _handleVolumeData(volumes) {
     // First, calculate total GBs and volumes by category

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -38,7 +38,17 @@ class HouseKeeper {
     this.tagger = tagger;
   }
 
-  async _handleVolumeData(volume) {}
+  _calculateVolumeTotals(volumes) {}
+
+  _submitVolumeTotals(totalsByCategory) {}
+
+  _handleVolumeData(volumes) {
+    // First, calculate total GBs and volumes by category
+    let totals = this._calculateVolumeTotals(volumes);
+
+    // Now, send an update to each corresponding statsum series with current totals.
+    this._submitVolumeTotals(totals);
+  }
 
   async _sweepVolumes(region) {
     // Collect all volume objects returned from AWS in a single array
@@ -64,7 +74,8 @@ class HouseKeeper {
       hasNextToken = (nextToken != null)
     }
 
-    await Promise.all(volumes.Volumes.map(this._handleVolumeData));
+    // After accumlating all of the volumes returned by AWS, process the results.
+    this._handleVolumeData(volumes);
   }
 
   async sweep() {

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -42,14 +42,12 @@ class HouseKeeper {
   _calculateVolumeTotals(tabulatedVolumes) {
     let totalVolumes = {};
     
-    Object.keys(tabulatedVolumes).forEach(function(volumesInRegion) {
-      tabulatedVolumes[volumesInRegion].forEach(function(volume) {        
-        let region = volume.AvailabilityZone;
+    Object.keys(tabulatedVolumes).forEach(function(region) {
+      // Initialize totals for each region
+      totalVolumes[region] = {};
+      
+      tabulatedVolumes[region].forEach(function(volume) {
         let type = volume.VolumeType;
-        
-        if (!(region in totalVolumes)) {
-          totalVolumes[region] = {};
-        }
         
         if (!(type in totalVolumes[region])) {
           totalVolumes[region][type] = {};

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -61,7 +61,7 @@ class HouseKeeper {
 
       volumes = volumes.concat(awsResults.Volumes);
       nextToken = awsResults.NextToken;
-      hasNextToken = (nextToken !== null)
+      hasNextToken = (nextToken != null)
     }
 
     await Promise.all(volumes.Volumes.map(this._handleVolumeData));

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -55,7 +55,7 @@ class HouseKeeper {
           Name: 'status',
           Values: ['available', 'in-use'],
         }],
-        MaxResults: 100,
+        MaxResults: 500, // This is the maximum page size allowed by the describeVolumes endpoint.
         NextToken: nextToken
       });
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -61,6 +61,7 @@ class HouseKeeper {
 
       volumes = volumes.concat(awsResults.Volumes);
       nextToken = awsResults.NextToken;
+      hasNextToken = (nextToken !== null)
     }
 
     await Promise.all(volumes.Volumes.map(this._handleVolumeData));

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -83,8 +83,7 @@ class HouseKeeper {
     });
     
     let tabulatedVolumes = await Promise.all(volumes.Volumes.map(this._handleVolumeData));
-    let totalVolumes = this._calculateTotals(tabulatedVolumes);
-    return totalVolumes;
+    return this._calculateTotals(tabulatedVolumes);
   }
 
   async sweep() {

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -137,7 +137,6 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
-      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,
@@ -196,7 +195,6 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(regions.length);
     assume(await state.listSpotRequests()).has.lengthOf(regions.length);
     assume(outcome[region]).deeply.equals({
-      volumes: {},
       state: {
         missingRequests: 1,
         missingInstances: 1,
@@ -317,7 +315,6 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
-      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -366,7 +366,7 @@ describe('House Keeper', () => {
     assume(describeVolumesStub.callCount).equals(regions.length);
   });
 
-  it.only('should call describeVolumes endpoint again if NextToken is provided', async() => {
+  it('should call describeVolumes endpoint again if NextToken is provided', async() => {
     describeVolumesStub.withArgs(sinon.match(function(value) {
       return value === ec2['us-west-2']; 
     })).onFirstCall().returns({

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -366,7 +366,7 @@ describe('House Keeper', () => {
     assume(describeVolumesStub.callCount).equals(regions.length);
   });
 
-  it('should call describeVolumes endpoint again if NextToken is provided', async() => {
+  it.only('should call describeVolumes endpoint again if NextToken is provided', async() => {
     describeVolumesStub.withArgs(sinon.match(function(value) {
       return value === ec2['us-west-2']; 
     })).onFirstCall().returns({

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -527,7 +527,7 @@ describe('House Keeper', () => {
     sinon.assert.match(calculateTotalVolumesSpy.firstCall.returnValue, expectedTotals);
   });
   
-  it.only('should return total size and counts of all volumes when the volumes are of different regions', async() => {
+  it('should return total size and counts of all volumes when the volumes are of different regions', async() => {
     describeVolumesStub.withArgs(sinon.match(value => {
       return value === ec2['us-east-2']; 
     })).onFirstCall().returns({

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -137,6 +137,7 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
+      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,
@@ -195,6 +196,7 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(regions.length);
     assume(await state.listSpotRequests()).has.lengthOf(regions.length);
     assume(outcome[region]).deeply.equals({
+      volumes: {},
       state: {
         missingRequests: 1,
         missingInstances: 1,
@@ -315,6 +317,7 @@ describe('House Keeper', () => {
     assume(await state.listInstances()).has.lengthOf(0);
     assume(await state.listSpotRequests()).has.lengthOf(0);
     assume(outcome[region]).deeply.equals({
+      volumes: {},
       state: {
         missingRequests: 0,
         missingInstances: 0,
@@ -333,7 +336,7 @@ describe('House Keeper', () => {
     }
   });
 
-  it('should call sweepVolumes exactly once', async() => {
+  it('should call sweepVolumes exactly once per region', async() => {
     houseKeeperMock.expects("_sweepVolumes").exactly(regions.length);
     
     await houseKeeper.sweep();
@@ -342,14 +345,14 @@ describe('House Keeper', () => {
 
   it('should not fail if no volume data is returned', async() => {
     houseKeeperMock.expects("_handleVolumeData").never();
-
+    
     await houseKeeper.sweep();
     houseKeeperMock.verify();
   });
   
   it('should call handleVolumeData exactly once per volume', async() => {
     houseKeeperMock.expects("_handleVolumeData").twice();
-      
+    
     describeVolumesStub.withArgs(sinon.match(function(value) {
       return value === ec2['us-west-2'] 
     })).returns({
@@ -379,8 +382,7 @@ describe('House Keeper', () => {
         VolumeType: "standard",
       }]
     });
-
-     
+    
     await houseKeeper.sweep();
     houseKeeperMock.verify();
    });


### PR DESCRIPTION
## Overview
This PR updates the implementation of _calculateVolumeTotals() to be able to integrate with @rstiyer's PR (https://github.com/rstiyer/ec2-manager/pull/2). I merged @rstiyer's commits, because @rstiyer updated how we will call `_sweepVolumes()` and `_handleVolumes()`. Also, the EBS volume totals are now of the form: 
```
{
  ${region}: {
    ${type}: {
      active: {
        gb: value,
        count: value,
      },
      unused: {
        gb: value,
        count: value,
      }
    }, ...
  }, ...
}
```

## Changes from @rstiyer's PR #2 
In `_submitVolumeTotals()`, the innermost loop now goes through the volumes by type as if it was an object not a list of objects.

Perhaps, this PR should've been made to the rstiyer/update-totals branch so what I changed is more evident. Feel free to ask me to clarify because I don't think I've explained it too well.

## Added util module
The `util` module can print the entire object using `console.log()` instead of printing something like `[object Object]`; e.g. `console.log(util.inspect(myObject, false, null));`. I added this `util` module primarily for debugging purposes.
See https://nodejs.org/api/util.html#util_util_inspect_object_options for more information.

## Tests
I implemented a few tests for `_calculateVolumeTotals()` when there are no volumes retrieved, when volumes retrieved belong to the same type and region, and when the volumes retrieved belong to different types but same region.